### PR TITLE
Use Digest::SHA instead of Digest::SHA1

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,7 @@ WriteMakefile(
     ),
 
     PREREQ_PM => {
-        'Digest::SHA1' => 0,
+        'Digest::SHA' => 0,
         'MIME::Base64' => 0,
         'Mojolicious'  => '2.49',
         'Storable'     => 0,

--- a/lib/MojoX/Session.pm
+++ b/lib/MojoX/Session.pm
@@ -11,7 +11,7 @@ use Mojo::Loader;
 use Mojo::ByteStream;
 use Mojo::Transaction::HTTP;
 use MojoX::Session::Transport::Cookie;
-use Digest::SHA1;
+use Digest::SHA;
 
 my $PRIVATE_IP_FIELD = 'mojox.session.ip_address';
 
@@ -382,7 +382,7 @@ sub _generate_sid {
     my $self = shift;
 
     # based on CGI::Session::ID
-    my $sha1 = Digest::SHA1->new;
+    my $sha1 = Digest::SHA->new(1);
     $sha1->add($$, time, rand(time));
     $self->sid($sha1->hexdigest);
 }


### PR DESCRIPTION
Major distros now only package Digest::SHA, so referencing Digest::SHA1 pulls in unwanted dependencies.

The new module has the same interface, so the changes are really minor.
