### PR TITLE
Previous fix for cpanm issue was incomplete

### DIFF
--- a/lib/MojoX/Session/Store/Dbi.pm
+++ b/lib/MojoX/Session/Store/Dbi.pm
@@ -90,7 +90,7 @@ __END__
 
 =head1 NAME
 
-MojoX::Session::Store::DBI - DBI Store for MojoX::Session
+MojoX::Session::Store::Dbi - Dbi Store for MojoX::Session
 
 =head1 SYNOPSIS
 
@@ -102,18 +102,18 @@ MojoX::Session::Store::DBI - DBI Store for MojoX::Session
     );
 
     my $session = MojoX::Session->new(
-        store => MojoX::Session::Store::DBI->new(dbh  => $dbh),
+        store => MojoX::Session::Store::Dbi->new(dbh  => $dbh),
         ...
     );
 
 =head1 DESCRIPTION
 
-L<MojoX::Session::Store::DBI> is a store for L<MojoX::Session> that stores a
+L<MojoX::Session::Store::Dbi> is a store for L<MojoX::Session> that stores a
 session in a database.
 
 =head1 ATTRIBUTES
 
-L<MojoX::Session::Store::DBI> implements the following attributes.
+L<MojoX::Session::Store::Dbi> implements the following attributes.
 
 =head2 C<dbh>
 
@@ -140,7 +140,7 @@ Data column name. Default is 'data'.
 
 =head1 METHODS
 
-L<MojoX::Session::Store::DBI> inherits all methods from
+L<MojoX::Session::Store::Dbi> inherits all methods from
 L<MojoX::Session::Store>.
 
 =head2 C<create>

--- a/lib/MojoX/Session/Store/Dbic.pm
+++ b/lib/MojoX/Session/Store/Dbic.pm
@@ -82,7 +82,7 @@ __END__
 
 =head1 NAME
 
-MojoX::Session::Store::DBIC - DBIx::Class Store for MojoX::Session
+MojoX::Session::Store::Dbic - DBIx::Class Store for MojoX::Session
 
 =head1 SYNOPSIS
 
@@ -96,18 +96,18 @@ MojoX::Session::Store::DBIC - DBIx::Class Store for MojoX::Session
     my $schema = DB->connect($dsn, $user, $pass, \%attr);
     my $rs = $schema->resultset('Session');
     my $session = MojoX::Session->new(
-        store => MojoX::Session::Store::DBI->new(resultset => $rs),
+        store => MojoX::Session::Store::Dbi->new(resultset => $rs),
         ...
     );
 
 =head1 DESCRIPTION
 
-L<MojoX::Session::Store::DBIC> is a store for L<MojoX::Session> that stores a
+L<MojoX::Session::Store::Dbic> is a store for L<MojoX::Session> that stores a
 session in a database using DBIx::Class.
 
 =head1 ATTRIBUTES
 
-L<MojoX::Session::Store::DBIC> implements the following attributes.
+L<MojoX::Session::Store::Dbic> implements the following attributes.
 
 =head2 C<resultset>
 
@@ -130,7 +130,7 @@ Data column name. Default is 'data'.
 
 =head1 METHODS
 
-L<MojoX::Session::Store::DBIC> inherits all methods from
+L<MojoX::Session::Store::Dbic> inherits all methods from
 L<MojoX::Session::Store>.
 
 =head2 C<create>


### PR DESCRIPTION
Some code and documentation still referred to the uppercase (DBI / DBIC) instead of Dbi and Dbic.
