### PR TITLE
Load/Flush the session

### DIFF
--- a/lib/MojoX/Session/Transport/Cookie.pm
+++ b/lib/MojoX/Session/Transport/Cookie.pm
@@ -10,7 +10,7 @@ use Mojo::Cookie::Response;
 
 __PACKAGE__->attr(name => 'sid');
 __PACKAGE__->attr(path => '/');
-__PACKAGE__->attr([qw/domain httponly secure/]);
+__PACKAGE__->attr([qw/domain httponly secure samesite/]);
 
 sub get {
     my ($self) = @_;
@@ -38,6 +38,7 @@ sub set {
     $cookie->domain($self->domain);
     $cookie->httponly($self->httponly);
     $cookie->secure($self->secure);
+    $cookie->samesite($self->samesite);
     $cookie->expires($expires);
 
     $cookie->max_age(0) if $expires < time;

--- a/lib/Mojolicious/Plugin/Session.pm
+++ b/lib/Mojolicious/Plugin/Session.pm
@@ -24,16 +24,19 @@ sub register {
             $session->tx($self->tx);
 
             $init->($self, $session) if $init;
+            $session->load or $session->create; # really?!
 
             $self->stash($stash_key => $session);
+            return;
         }
     );
 
     $app->hook(
         after_dispatch => sub {
             my $self = shift;
-
-            $self->stash($stash_key)->flush;
+            my $session = $self->stash($stash_key);
+            $session->flush if $session;
+            return;
         }
     );
 }


### PR DESCRIPTION
Hello Вячеслав,

thank you very much for implementing MojoX::Session - this is exactly what I need for Mojolicious session management. 
Maybe I understand the use of MojoX::Session wrong, but I found that the session stuff does not automatically get loaded/saved with Mojolicious 8.3 - this PR below adds that.

The PR also adds a `samesite` attribute to the Cookie transport to have a setting for the SameSite attribute.

I hope you're still interested in the module and can tell me if I'm wrong about loading/saving (and the correct way to do this) :) - if what I'm doing is not wrong and you don't want to maintain the module anymore, I'm also willing to do co-maintenance,

Thank you again!